### PR TITLE
Simplify code

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,6 @@
     "hubot-scripts",
     "github"
   ],
-  "peerDependencies": {
-    "coffee-script": "^1.7.0"
-  },
   "author": "Mark Wilkerson <mark@segfawlt.net>",
   "license": "MIT",
   "bugs": {

--- a/scripts/compare.coffee
+++ b/scripts/compare.coffee
@@ -1,28 +1,28 @@
 # Description:
-#  Returns a github release/branch comparison URL for a
+#  Generates a GitHub comparison URL
 #
 # Configuration:
-#   HUBOT_GITHUB_USER
+#   HUBOT_GITHUB_USER - GitHub org/user to use if none explicitly given
 #
 # Commands:
-#   hubot compare me <repo> <release/branch> <release/branch> - Reply with url to github compare ¬
+#   hubot compare me <repo> <treeish> <treeish> - Reply with url to github compare page
+#
+# Notes:
+#   None
 #
 # Author:
-#  markhuge 
+#  markhuge
 
 user = process.env.HUBOT_GITHUB_USER
-module.exports = (robot) ->
-  if user
-    robot.respond ///
-        compare\ me\ (:?#{user}\/)*([\w-]+)\ ([\w\.\/\\-]+)\s([\w\.\/\\-]+)
-      ////i, (msg) ->
-      msg.send "https://github.com/#{user}/#{msg.match[2]}/compare/#{msg.match[3]}...#{msg.match[4]}"
 
-    robot.respond ///
-        compare\ me\ ([^#{user}][\w-]+\/[\w-]+)\ ([\w\.\/\\-]+)\s([\w\.\/\\-]+)
-      ///i, (msg) ->
-      msg.send "https://github.com/#{msg.match[1]}/compare/#{msg.match[2]}...#{msg.match[3]}"
-  
-  else
-    robot.respond /compare me ([\w-]+\/[\w-]+) ([\w\.\/\\-]+)\s([\w\.\/\\-]+)/i, (msg) ->
-      msg.send "https://github.com/#{msg.match[1]}/compare/#{msg.match[2]}...#{msg.match[3]}"
+module.exports = (robot) ->
+  robot.respond /compare (?:me )?([\w-.\/]+) ([\w-.\/]+) (?:to )?([\w-.\/]+)/i, (msg) ->
+    [_, repo, from, to] = msg.match
+
+    unless ~repo.indexOf '/'
+      if user
+        repo = "#{user}/#{repo}"
+      else
+        return # not a valid repo, so stay silent
+
+    msg.send "https://github.com/#{repo}/compare/#{from}...#{to}"

--- a/scripts/compare.coffee
+++ b/scripts/compare.coffee
@@ -19,7 +19,7 @@ module.exports = (robot) ->
   robot.respond /compare (?:me )?([\w-.\/]+) ([\w-.\/]+) (?:to )?([\w-.\/]+)/i, (msg) ->
     [_, repo, from, to] = msg.match
 
-    unless ~repo.indexOf '/'
+    if '/' not in repo
       if user
         repo = "#{user}/#{repo}"
       else


### PR DESCRIPTION
Closes #1 and #5
## Changes
- Massively simplify code while retaining functionality
- Remove need for dependency on coffee-script >= 1.7
- Bring docs into line with latest standards
- Allow syntax of requests to be a little more flexible
## Testing

**When no default user is set:**

```
Hubot> hubot compare me user/repo develop 1.0.1
Hubot> https://github.com/user/repo/compare/develop...1.0.1
Hubot> hubot compare hubot-github-compare develop master
-- nothing here, Hubot just ignores you --
```

**When default user is set to markhuge:**

```
Hubot> hubot compare me user/repo develop 1.0.1
Hubot> https://github.com/user/repo/compare/develop...1.0.1
Hubot> hubot compare hubot-github-compare develop master
Hubot> https://github.com/markhuge/hubot-github-compare/compare/develop...master
```

---

**Syntax test script**

``` coffee
pattern = /compare (?:me )?([\w-.\/]+) ([\w-.\/]+) (?:to )?([\w-.\/]+)/i

tests = [
  'compare me owner/repo treeish treeish',
  'compare me hubot/repo treeish tree/ish',
  'compare me hubot-anything/repo treeish v1.0.0',
  'compare me hubot treeish tree-ish',
  'compare owner/repo treeish treeish',
  'compare hubot/repo treeish tree/ish',
  'compare hubot-anything/repo treeish v1.0.0',
  'compare hubot treeish tree-ish',
  'compare owner/repo treeish to treeish',
  'compare hubot/repo treeish to tree/ish',
  'compare hubot-anything/repo treeish to v1.0.0',
  'compare hubot.js treeish to tree-ish',
  'compare hubot treeish to'
]

space = "                                             "
pad = (str) ->
  str + space.substr 0, 45 - str.length

for test in tests
  console.log pad(test), Array.prototype.slice.call(test.match(pattern) ? [], 1)
```

**Results:**

```
$ coffee test.coffee
compare me owner/repo treeish treeish         [ 'owner/repo', 'treeish', 'treeish' ]
compare me hubot/repo treeish tree/ish        [ 'hubot/repo', 'treeish', 'tree/ish' ]
compare me hubot-anything/repo treeish v1.0.0 [ 'hubot-anything/repo', 'treeish', 'v1.0.0' ]
compare me hubot treeish tree-ish             [ 'hubot', 'treeish', 'tree-ish' ]
compare owner/repo treeish treeish            [ 'owner/repo', 'treeish', 'treeish' ]
compare hubot/repo treeish tree/ish           [ 'hubot/repo', 'treeish', 'tree/ish' ]
compare hubot-anything/repo treeish v1.0.0    [ 'hubot-anything/repo', 'treeish', 'v1.0.0' ]
compare hubot treeish tree-ish                [ 'hubot', 'treeish', 'tree-ish' ]
compare owner/repo treeish to treeish         [ 'owner/repo', 'treeish', 'treeish' ]
compare hubot/repo treeish to tree/ish        [ 'hubot/repo', 'treeish', 'tree/ish' ]
compare hubot-anything/repo treeish to v1.0.0 [ 'hubot-anything/repo', 'treeish', 'v1.0.0' ]
compare hubot.js treeish to tree-ish          [ 'hubot.js', 'treeish', 'tree-ish' ]
compare hubot treeish to                      [ 'hubot', 'treeish', 'to' ]
```
